### PR TITLE
feat: Add Custom Textfield (RN v0.69)

### DIFF
--- a/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -578,6 +578,7 @@ export type NativeProps = $ReadOnly<{|
   /**
    * Taskade Specific Changes
    */
+  textDecorationColor?: ?ColorValue,
   taskadeEditorInput?: ?boolean,
 
   /**
@@ -714,6 +715,7 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {
     borderLeftColor: {process: require('../../StyleSheet/processColor')},
     borderTopLeftRadius: true,
     borderTopColor: {process: require('../../StyleSheet/processColor')},
+    textDecorationColor: {process: require('../../StyleSheet/processColor')},
   },
 };
 

--- a/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -576,6 +576,11 @@ export type NativeProps = $ReadOnly<{|
   fontFamily?: ?string,
 
   /**
+   * Taskade Specific Changes
+   */
+  taskadeEditorInput?: ?boolean,
+
+  /**
    * I cannot find where these are defined but JS complains without them.
    */
   textAlignVertical?: ?string,

--- a/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -122,6 +122,7 @@ const RCTTextInputViewConfig = {
     editable: true,
     inputAccessoryViewID: true,
     caretHidden: true,
+    taskadeEditorInput: true,
     enablesReturnKeyAutomatically: true,
     placeholderTextColor: {process: require('../../StyleSheet/processColor')},
     clearButtonMode: true,

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -514,6 +514,11 @@ export type Props = $ReadOnly<{|
    */
   caretHidden?: ?boolean,
 
+   /*
+   * If `true`, taskadeEditorInput is activated. The default value is `false`.
+   */
+  taskadeEditorInput?: ?boolean,
+
   /*
    * If `true`, contextMenuHidden is hidden. The default value is `false`.
    */

--- a/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/Libraries/StyleSheet/StyleSheetTypes.js
@@ -607,7 +607,7 @@ export type ____TextStyle_InternalCore = $ReadOnly<{
     | 'underline'
     | 'line-through'
     | 'underline line-through',
-  textDecorationStyle?: 'solid' | 'double' | 'dotted' | 'dashed',
+  textDecorationStyle?: 'solid' | 'double' | 'dotted' | 'dashed' | 'taskade',
   textDecorationColor?: ____ColorValue_Internal,
   textTransform?: 'none' | 'capitalize' | 'uppercase' | 'lowercase',
   writingDirection?: 'auto' | 'ltr' | 'rtl',

--- a/Libraries/Text/Text/RCTTextShadowView.m
+++ b/Libraries/Text/Text/RCTTextShadowView.m
@@ -10,6 +10,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTShadowView+Layout.h>
 #import <React/RCTUIManager.h>
+#import <React/TaskadeLayoutManager.h>
 #import <yoga/Yoga.h>
 
 #import "NSTextStorage+FontScaling.h"
@@ -232,7 +233,7 @@
     _maximumNumberOfLines > 0 ? _lineBreakMode : NSLineBreakByClipping;
   textContainer.maximumNumberOfLines = _maximumNumberOfLines;
 
-  NSLayoutManager *layoutManager = [NSLayoutManager new];
+  TaskadeLayoutManager *layoutManager = [TaskadeLayoutManager new];
   layoutManager.usesFontLeading = NO;
   [layoutManager addTextContainer:textContainer];
 

--- a/Libraries/Text/Text/TaskadeLayoutManager.h
+++ b/Libraries/Text/Text/TaskadeLayoutManager.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Taskade 
+ * A custom layout manager to support gap-less underlined text
+*/
+
+#import <UIKit/UIKit.h>
+
+@interface TaskadeLayoutManager : NSLayoutManager 
+
+- (void)drawUnderlineForRect:(CGRect)rect;
+
+- (void)drawUnderlineForGlyphRange:(NSRange)glyphRange 
+                underlineType:(NSUnderlineStyle)underlineVal 
+                baselineOffset:(CGFloat)baselineOffset 
+                lineFragmentRect:(CGRect)lineRect 
+                lineFragmentGlyphRange:(NSRange)lineGlyphRange 
+                containerOrigin:(CGPoint)containerOrigin;
+@end

--- a/Libraries/Text/Text/TaskadeLayoutManager.m
+++ b/Libraries/Text/Text/TaskadeLayoutManager.m
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Taskade 
+*/
+
+#import "TaskadeLayoutManager.h"
+
+@implementation TaskadeLayoutManager
+
+- (void)drawUnderlineForRect:(CGRect)rect
+{
+  UIBezierPath *path = [UIBezierPath new];
+  path.lineWidth = 3.5;
+  [path moveToPoint: CGPointMake(CGRectGetMinX(rect), CGRectGetMaxY(rect))];
+  [path addLineToPoint: CGPointMake(CGRectGetMaxX(rect), CGRectGetMaxY(rect))];
+  [path stroke];
+}
+
+- (void)drawUnderlineForGlyphRange:(NSRange)glyphRange 
+                     underlineType:(NSUnderlineStyle)underlineVal 
+                    baselineOffset:(CGFloat)baselineOffset 
+                  lineFragmentRect:(CGRect)lineRect 
+            lineFragmentGlyphRange:(NSRange)lineGlyphRange 
+                   containerOrigin:(CGPoint)containerOrigin
+{
+  NSTextContainer *textContainer = [self textContainerForGlyphAtIndex:glyphRange.location effectiveRange: nil];
+  CGRect boundingRect = [self boundingRectForGlyphRange:glyphRange inTextContainer:textContainer];
+  CGRect offsetRect = CGRectOffset(boundingRect, containerOrigin.x, containerOrigin.y );
+  UIColor *color = [self.textStorage attribute:NSUnderlineColorAttributeName atIndex:glyphRange.location effectiveRange: nil];
+  
+  if (color) {
+    [color setStroke];
+  }
+
+  [self drawUnderlineForRect:offsetRect];
+}
+
+@end

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.h
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.h
@@ -35,6 +35,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) BOOL caretHidden;
 
+//@Taskadev1 Editor input prop declaration
+@property (nonatomic, assign) BOOL taskadeEditorInput;
+
 @property (nonatomic, strong, nullable) NSString *inputAccessoryViewID;
 
 @end

--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -219,6 +219,11 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
   NSString *newText =
     [_backedTextInputView.textInputDelegate textInputShouldChangeText:text inRange:range];
 
+  //@Taskadev1 Prevent enter for editor input
+  if (_backedTextInputView.taskadeEditorInput && [text isEqualToString:@"\n"]) {
+    return NO;
+  }
+
   if (newText == nil) {
     return NO;
   }

--- a/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
+++ b/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL contextMenuHidden;
 @property (nonatomic, assign, getter=isEditable) BOOL editable;
 @property (nonatomic, assign) BOOL caretHidden;
+@property (nonatomic, assign) BOOL taskadeEditorInput; //@Taskdev1 Editor input prop declaration
 @property (nonatomic, assign) BOOL enablesReturnKeyAutomatically;
 @property (nonatomic, assign) UITextFieldViewMode clearButtonMode;
 @property (nonatomic, getter=isScrollEnabled) BOOL scrollEnabled;

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.h
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.h
@@ -46,6 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL selectTextOnFocus;
 @property (nonatomic, assign) BOOL clearTextOnFocus;
 @property (nonatomic, assign) BOOL secureTextEntry;
+@property (nonatomic, assign) BOOL taskadeEditorInput;   //@Taskdev1 Editor input prop declaration
 @property (nonatomic, copy) RCTTextSelection *selection;
 @property (nonatomic, strong, nullable) NSNumber *maxLength;
 @property (nonatomic, copy, nullable) NSAttributedString *attributedText;

--- a/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
@@ -48,6 +48,7 @@ RCT_REMAP_VIEW_PROPERTY(caretHidden, backedTextInputView.caretHidden, BOOL)
 RCT_REMAP_VIEW_PROPERTY(clearButtonMode, backedTextInputView.clearButtonMode, UITextFieldViewMode)
 RCT_REMAP_VIEW_PROPERTY(scrollEnabled, backedTextInputView.scrollEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(secureTextEntry, backedTextInputView.secureTextEntry, BOOL)
+RCT_REMAP_VIEW_PROPERTY(taskadeEditorInput, backedTextInputView.taskadeEditorInput, BOOL) //@Taskdev1 Editor
 RCT_EXPORT_VIEW_PROPERTY(autoFocus, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(blurOnSubmit, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(clearTextOnFocus, BOOL)

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -331,6 +331,7 @@ RCT_ENUM_CONVERTER(
       @"double" : @(NSUnderlineStyleDouble),
       @"dotted" : @(NSUnderlinePatternDot | NSUnderlineStyleSingle),
       @"dashed" : @(NSUnderlinePatternDash | NSUnderlineStyleSingle),
+      @"taskade": @(NSUnderlineStyleThick + NSUnderlineStyleSingle),
     }),
     NSUnderlineStyleSingle,
     integerValue)

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -103,6 +103,7 @@ public class ViewProps {
   public static final String TEXT_ALIGN = "textAlign";
   public static final String TEXT_ALIGN_VERTICAL = "textAlignVertical";
   public static final String TEXT_DECORATION_LINE = "textDecorationLine";
+  public static final String TEXT_DECORATION_COLOR = "textDecorationColor";
   public static final String TEXT_BREAK_STRATEGY = "textBreakStrategy";
   public static final String OPACITY = "opacity";
   public static final String OVERFLOW = "overflow";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -212,7 +212,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
                     textShadowNode.getThemedContext().getAssets())));
       }
       if (textShadowNode.mIsUnderlineTextDecorationSet) {
-        ops.add(new SetSpanOperation(start, end, new ReactUnderlineSpan()));
+        ops.add(new SetSpanOperation(start, end, new ReactUnderlineSpan(textShadowNode.mTextDecorationColor)));
       }
       if (textShadowNode.mIsLineThroughTextDecorationSet) {
         ops.add(new SetSpanOperation(start, end, new ReactStrikethroughSpan()));
@@ -345,6 +345,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
   protected boolean mIncludeFontPadding = true;
   protected boolean mAdjustsFontSizeToFit = false;
   protected float mMinimumFontScale = 0;
+  protected @Nullable Integer mTextDecorationColor;
 
   /**
    * mFontStyle can be {@link Typeface#NORMAL} or {@link Typeface#ITALIC}. mFontWeight can be {@link
@@ -494,6 +495,12 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
       }
       markUpdated();
     }
+  }
+
+  @ReactProp(name = ViewProps.TEXT_DECORATION_COLOR, customType = "Color")
+  public void setTextDecorationColor(@Nullable Integer color) {
+    mTextDecorationColor = color;
+    markUpdated();
   }
 
   @ReactProp(name = ViewProps.ACCESSIBILITY_ROLE)

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactUnderlineSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactUnderlineSpan.java
@@ -7,9 +7,53 @@
 
 package com.facebook.react.views.text;
 
+import android.os.Build;
+import android.util.Log;
+import android.text.TextPaint;
 import android.text.style.UnderlineSpan;
+import androidx.annotation.Nullable;
+
+import java.lang.reflect.Method;
 
 /*
  * Wraps {@link UnderlineSpan} as a {@link ReactSpan}.
  */
-public class ReactUnderlineSpan extends UnderlineSpan implements ReactSpan {}
+public class ReactUnderlineSpan extends UnderlineSpan implements ReactSpan {
+  private final @Nullable Integer mUnderlineColor;
+
+  public ReactUnderlineSpan(@Nullable Integer color) {
+    mUnderlineColor = color;
+  }
+
+  @Override
+  public void updateDrawState(TextPaint textPaint) {
+    if (mUnderlineColor == null) {
+      super.updateDrawState(textPaint);
+    } else {
+      float mTaskadeUnderlineThickness = 8.0f;
+
+      /**
+       * Enables underline color support for TextPaint. The method is publicly available starting from API 29
+       * and was hidden before. We will have to resort to reflection techniques to ensure we can use this API.
+       * The API is defined here (as of this diff):
+       * https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android13-gsi/core/java/android/text/TextPaint.java 
+       */
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        textPaint.underlineColor = mUnderlineColor;
+        textPaint.underlineThickness = mTaskadeUnderlineThickness;
+      } else {
+        try {
+          final Method method = TextPaint.class.getMethod("setUnderlineText", Integer.TYPE, Float.TYPE);
+          method.invoke(textPaint, mUnderlineColor, mTaskadeUnderlineThickness);
+        } catch (final Exception e) {
+          // Render default underline
+          textPaint.setUnderlineText(true);
+        }
+      }
+    }
+  }
+
+  public int getUnderlineColor() {
+    return mUnderlineColor;
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -78,6 +78,7 @@ public class TextAttributeProps {
   protected int mColor;
   protected boolean mIsBackgroundColorSet = false;
   protected int mBackgroundColor;
+  protected @Nullable Integer mTextDecorationColor = null;
 
   protected int mNumberOfLines = UNSET;
   protected int mFontSize = UNSET;
@@ -185,6 +186,7 @@ public class TextAttributeProps {
         case TA_KEY_BEST_WRITING_DIRECTION:
           break;
         case TA_KEY_TEXT_DECORATION_COLOR:
+          result.setTextDecorationColor(entry.getIntValue());
           break;
         case TA_KEY_TEXT_DECORATION_LINE:
           result.setTextDecorationLine(entry.getStringValue());
@@ -241,6 +243,10 @@ public class TextAttributeProps {
     result.setTextDecorationLine(getStringProp(props, ViewProps.TEXT_DECORATION_LINE));
     result.setTextShadowOffset(
         props.hasKey(PROP_SHADOW_OFFSET) ? props.getMap(PROP_SHADOW_OFFSET) : null);
+    result.setTextDecorationColor(
+        props.hasKey(ViewProps.TEXT_DECORATION_COLOR)
+            ? props.getInt(ViewProps.TEXT_DECORATION_COLOR, 0)
+            : null);
     result.setTextShadowRadius(getFloatProp(props, PROP_SHADOW_RADIUS, 1));
     result.setTextShadowColor(getIntProp(props, PROP_SHADOW_COLOR, DEFAULT_TEXT_SHADOW_COLOR));
     result.setTextTransform(getStringProp(props, PROP_TEXT_TRANSFORM));
@@ -474,6 +480,10 @@ public class TextAttributeProps {
         }
       }
     }
+  }
+
+    private void setTextDecorationColor(@Nullable Integer color) {
+    mTextDecorationColor = color;
   }
 
   private void setTextShadowOffset(ReadableMap offsetMap) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -160,7 +160,7 @@ public class TextLayoutManager {
                       context.getAssets())));
         }
         if (textAttributes.mIsUnderlineTextDecorationSet) {
-          ops.add(new SetSpanOperation(start, end, new ReactUnderlineSpan()));
+          ops.add(new SetSpanOperation(start, end, new ReactUnderlineSpan(textAttributes.mTextDecorationColor)));
         }
         if (textAttributes.mIsLineThroughTextDecorationSet) {
           ops.add(new SetSpanOperation(start, end, new ReactStrikethroughSpan()));

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -170,7 +170,7 @@ public class TextLayoutManagerMapBuffer {
                       context.getAssets())));
         }
         if (textAttributes.mIsUnderlineTextDecorationSet) {
-          ops.add(new SetSpanOperation(start, end, new ReactUnderlineSpan()));
+          ops.add(new SetSpanOperation(start, end, new ReactUnderlineSpan(textAttributes.mTextDecorationColor)));
         }
         if (textAttributes.mIsLineThroughTextDecorationSet) {
           ops.add(new SetSpanOperation(start, end, new ReactStrikethroughSpan()));

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -125,6 +125,8 @@ public class ReactEditText extends AppCompatEditText
       new FabricViewStateManager();
   protected boolean mDisableTextDiffing = false;
 
+  // @Taskadev1 Editor input prop declaration
+  protected boolean mIsTaskadeEditor = false;
   protected boolean mIsSettingTextFromState = false;
 
   private static final KeyListener sKeyListener = QwertyKeyListener.getInstanceForFullKeyboard();
@@ -392,6 +394,11 @@ public class ReactEditText extends AppCompatEditText
 
   public void setOnKeyPress(boolean onKeyPress) {
     mOnKeyPress = onKeyPress;
+  }
+
+  // @Taskadev1 Set editor input prop
+  public void setTaskadeEditorInput(boolean isTaskadeEditor) {
+    mIsTaskadeEditor = isTaskadeEditor;
   }
 
   public boolean getBlurOnSubmit() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -118,6 +118,7 @@ public class ReactEditText extends AppCompatEditText
   private int mFontStyle = UNSET;
   private boolean mAutoFocus = false;
   private boolean mDidAttachToWindow = false;
+  private @Nullable Integer mTextDecorationColor = null;
 
   private ReactViewBackgroundManager mReactBackgroundManager;
 
@@ -787,7 +788,12 @@ public class ReactEditText extends AppCompatEditText
     }
 
     if ((getPaintFlags() & Paint.UNDERLINE_TEXT_FLAG) != 0) {
-      workingText.setSpan(new ReactUnderlineSpan(), 0, workingText.length(), spanFlags);
+      workingText.setSpan(
+        new ReactUnderlineSpan(mTextDecorationColor),
+        0,
+        workingText.length(),
+        spanFlags
+      );
     }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -1152,6 +1158,10 @@ public class ReactEditText extends AppCompatEditText
 
   public void setAutoFocus(boolean autoFocus) {
     mAutoFocus = autoFocus;
+  }
+
+  public void setTextDecorationColor(@Nullable Integer color) {
+    mTextDecorationColor = color;
   }
 
   protected void applyTextAttributes() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -939,6 +939,13 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     }
   }
 
+  @ReactProp(name = ViewProps.TEXT_DECORATION_COLOR, customType = "Color")
+  public void setTextDecorationColor(ReactEditText view, @Nullable Integer color) {
+    if ((view.getPaintFlags() & Paint.UNDERLINE_TEXT_FLAG) != 0) {
+      view.setTextDecorationColor(color);
+    }
+  }
+
   @ReactPropGroup(
       names = {
         ViewProps.BORDER_WIDTH,

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -477,6 +477,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     view.setOnKeyPress(onKeyPress);
   }
 
+  @ReactProp(name = "taskadeEditorInput", defaultBoolean = false)
+  public void setTaskadeEditorInput(final ReactEditText view, boolean isTaskadeEditor) {
+    view.setTaskadeEditorInput(isTaskadeEditor);
+  }
+
   // Sets the letter spacing as an absolute point size.
   // This extra handling, on top of what ReactBaseTextShadowNode already does, is required for the
   // correct display of spacing in placeholder (hint) text.
@@ -1069,7 +1074,18 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     }
 
     @Override
-    public void afterTextChanged(Editable s) {}
+    public void afterTextChanged(Editable s) {
+      // @Taskadev1 Prevent newline from being created
+      if (mEditText.mIsTaskadeEditor) {
+        for (int i = s.length() - 1; i >= 0; i--) {
+            if (s.charAt(i) == '\n') {
+                s.delete(i, i + 1);
+                mEventDispatcher.dispatchEvent(new ReactTextInputKeyPressEvent(mEditText.getId(), "Enter"));
+                return;
+            }
+        }
+      }
+    }
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -930,11 +930,13 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     view.setPaintFlags(
         view.getPaintFlags() & ~(Paint.STRIKE_THRU_TEXT_FLAG | Paint.UNDERLINE_TEXT_FLAG));
 
-    for (String token : textDecorationLineString.split(" ")) {
-      if (token.equals("underline")) {
-        view.setPaintFlags(view.getPaintFlags() | Paint.UNDERLINE_TEXT_FLAG);
-      } else if (token.equals("line-through")) {
-        view.setPaintFlags(view.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
+    if (textDecorationLineString != null) {
+      for (String token : textDecorationLineString.split(" ")) {
+        if (token.equals("underline")) {
+          view.setPaintFlags(view.getPaintFlags() | Paint.UNDERLINE_TEXT_FLAG);
+        } else if (token.equals("line-through")) {
+          view.setPaintFlags(view.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
+        }
       }
     }
   }

--- a/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -487,6 +487,8 @@ inline void fromRawValue(
       result = TextDecorationStyle::Dotted;
     } else if (string == "dashed") {
       result = TextDecorationStyle::Dashed;
+    } else if (string == "taskade") {
+      result = TextDecorationStyle::Taskade;
     } else {
       LOG(ERROR) << "Unsupported TextDecorationStyle value: " << string;
       react_native_assert(false);
@@ -511,6 +513,8 @@ inline std::string toString(const TextDecorationStyle &textDecorationStyle) {
       return "dotted";
     case TextDecorationStyle::Dashed:
       return "dashed";
+    case TextDecorationStyle::Taskade:
+      return "taskade";
   }
 
   LOG(ERROR) << "Unsupported TextDecorationStyle value";

--- a/ReactCommon/react/renderer/attributedstring/primitives.h
+++ b/ReactCommon/react/renderer/attributedstring/primitives.h
@@ -81,7 +81,7 @@ enum class TextDecorationLineType {
   UnderlineStrikethrough
 };
 
-enum class TextDecorationStyle { Solid, Double, Dotted, Dashed };
+enum class TextDecorationStyle { Solid, Double, Dotted, Dashed, Taskade };
 
 enum class AccessibilityRole {
   None,

--- a/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -173,6 +173,10 @@ AndroidTextInputProps::AndroidTextInputProps(
           "textDecorationLine",
           sourceProps.textDecorationLine,
           {})),
+      textDecorationColor(convertRawProp(context, rawProps,
+          "textDecorationLine",
+          sourceProps.textDecorationColor,
+          {})),
       fontStyle(
           convertRawProp(context, rawProps, "fontStyle", sourceProps.fontStyle, {})),
       textShadowOffset(convertRawProp(context, rawProps,
@@ -300,6 +304,7 @@ folly::dynamic AndroidTextInputProps::getDynamic() const {
   props["textShadowColor"] = toAndroidRepr(textShadowColor);
   props["textShadowRadius"] = textShadowRadius;
   props["textDecorationLine"] = textDecorationLine;
+  props["textDecorationColor"] = toAndroidRepr(textDecorationColor);
   props["fontStyle"] = fontStyle;
   props["textShadowOffset"] = toDynamic(textShadowOffset);
   props["lineHeight"] = lineHeight;

--- a/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -120,6 +120,10 @@ AndroidTextInputProps::AndroidTextInputProps(
           "multiline",
           sourceProps.multiline,
           {false})),
+      taskadeEditorInput(convertRawProp(context, rawProps,
+          "taskadeEditorInput",
+          sourceProps.taskadeEditorInput,
+          {false})),
       placeholder(
           convertRawProp(context, rawProps, "placeholder", sourceProps.placeholder, {})),
       placeholderTextColor(convertRawProp(context, rawProps,
@@ -281,6 +285,7 @@ folly::dynamic AndroidTextInputProps::getDynamic() const {
   props["returnKeyType"] = returnKeyType;
   props["maxLength"] = maxLength;
   props["multiline"] = multiline;
+  props["taskadeEditorInput"] = taskadeEditorInput;
   props["placeholder"] = placeholder;
   props["placeholderTextColor"] = toAndroidRepr(placeholderTextColor);
   props["secureTextEntry"] = secureTextEntry;

--- a/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -129,6 +129,7 @@ class AndroidTextInputProps final : public ViewProps, public BaseTextProps {
   const std::string returnKeyType{};
   const int maxLength{0};
   const bool multiline{false};
+  const bool taskadeEditorInput{false};
   const std::string placeholder{};
   const SharedColor placeholderTextColor{};
   const bool secureTextEntry{false};

--- a/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -144,6 +144,7 @@ class AndroidTextInputProps final : public ViewProps, public BaseTextProps {
   const SharedColor textShadowColor{};
   const Float textShadowRadius{0.0};
   const std::string textDecorationLine{};
+  const SharedColor textDecorationColor{};
   const std::string fontStyle{};
   const AndroidTextInputTextShadowOffsetStruct textShadowOffset{};
   const Float lineHeight{0.0};

--- a/ReactCommon/react/renderer/components/textinput/iostextinput/TextInputProps.cpp
+++ b/ReactCommon/react/renderer/components/textinput/iostextinput/TextInputProps.cpp
@@ -82,6 +82,12 @@ TextInputProps::TextInputProps(
           "autoFocus",
           sourceProps.autoFocus,
           {})),
+      taskadeEditorInput(convertRawProp(
+          context,
+          rawProps,
+          "taskadeEditorInput",
+          sourceProps.taskadeEditorInput,
+          {})),
       selection(convertRawProp(
           context,
           rawProps,

--- a/ReactCommon/react/renderer/components/textinput/iostextinput/TextInputProps.h
+++ b/ReactCommon/react/renderer/components/textinput/iostextinput/TextInputProps.h
@@ -64,6 +64,7 @@ class TextInputProps final : public ViewProps, public BaseTextProps {
 
   bool onKeyPressSync{false};
   bool onChangeSync{false};
+  bool taskadeEditorInput{false};
 
   /*
    * Accessors

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextPrimitivesConversions.h
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextPrimitivesConversions.h
@@ -68,6 +68,8 @@ inline static NSUnderlineStyle RCTNSUnderlineStyleFromTextDecorationStyle(TextDe
       return NSUnderlinePatternDash | NSUnderlineStyleSingle;
     case TextDecorationStyle::Dotted:
       return NSUnderlinePatternDot | NSUnderlineStyleSingle;
+    case TextDecorationStyle::Taskade:
+      return NSUnderlineStyleThick + NSUnderlineStyleSingle;
   }
 }
 


### PR DESCRIPTION
## Custom Textfield

> Built on React Native: v0.69.12

### Features/Modifications:

1. feat(iOS, android): New `taskadeEditorInput` prop for `TextInput`
    * Remove `\n` characters on 'enter' key to prevent making a new line

2. feat(iOS): Add new `textDecorationStyle: 'taskade'` for customised thicker underline for Taskade Editor

3. feat(iOS): Add new LayoutManager for `Text` for Gapless underline
    * Similar to web `text-decoration-skip-ink`
    * [Source-code](https://medium.com/brill-app/implementing-custom-underline-styles-866c740be78a) 

4. feat(android): Add support for `textDecorationColor` prop in `Text` and `TextInput`

## iOS Build
No additional steps needed

## Android Build
Build AAR with docker `reactnativecommunity/react-native-android` with `tag 5.4`

```
docker run \
    --rm \
    --name rn-build \
    --env REACT_NATIVE_HERMES_SKIP_PREFAB=true \
    -v $PWD:/pwd \
    -w /pwd \
    reactnativecommunity/react-native-android:5.4 \
    /bin/sh \
    -c \
    "./gradlew :ReactAndroid:installArchives && ./gradlew :ReactAndroid:hermes-engine:installArchives"
```

### create .aar, then:
git add android --force
git commit -m 'my release commit'
git push
```
From [Building from source](https://reactnative.dev/contributing/how-to-build-from-source)